### PR TITLE
Add support for getCurrentLocation

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
 
-    api 'com.google.android.gms:play-services-location:17.0.0'
+    api 'com.google.android.gms:play-services-location:17.1.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"

--- a/library/src/main/java/com/patloew/colocation/CoLocation.kt
+++ b/library/src/main/java/com/patloew/colocation/CoLocation.kt
@@ -60,15 +60,15 @@ interface CoLocation {
     suspend fun isLocationAvailable(): Boolean
 
     /**
-     * Returns a single location fix on the device.
+     * Returns a single current location fix on the device. Unlike [getLastLocation()] that returns a cached location,
+     * this method could cause active location computation on the device. A single fresh location will be returned if
+     * the device location can be determined within reasonable time (tens of seconds), otherwise null will be returned.
      *
-     * Unlike [getLastLocation], this method could cause active location computation on the device.
+     * This method may return locations that are a few seconds old, but never returns much older locations. This is
+     * suitable for foreground applications that need a single fresh current location.
      *
-     * If a location is not available, which should happen very rarely, null will be returned. The best accuracy
-     * available while respecting the location permissions will be returned.
-     *
-     * This method may return locations that are a few seconds old, but never returns much older locations.
-     * This is suitable for foreground applications that need a single fresh current location.
+     * Background apps calling this method will be throttled under background location limits, so background apps may
+     * find the method returns null locations more often.
      *
      * @param priority One the PRIORITY_* in [LocationRequest].
      */

--- a/library/src/main/java/com/patloew/colocation/CoLocation.kt
+++ b/library/src/main/java/com/patloew/colocation/CoLocation.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.IntentSender
-import android.location.Geocoder
 import android.location.Location
 import androidx.annotation.RequiresPermission
 import com.google.android.gms.common.api.ResolvableApiException
@@ -59,6 +58,22 @@ interface CoLocation {
      */
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     suspend fun isLocationAvailable(): Boolean
+
+    /**
+     * Returns a single location fix on the device.
+     *
+     * Unlike [getLastLocation], this method could cause active location computation on the device.
+     *
+     * If a location is not available, which should happen very rarely, null will be returned. The best accuracy
+     * available while respecting the location permissions will be returned.
+     *
+     * This method may return locations that are a few seconds old, but never returns much older locations.
+     * This is suitable for foreground applications that need a single fresh current location.
+     *
+     * @param priority One the PRIORITY_* in [LocationRequest].
+     */
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    suspend fun getCurrentLocation(priority: Int): Location?
 
     /**
      * Returns the best most recent location currently available.

--- a/library/src/test/java/com/patloew/colocation/CoLocationTest.kt
+++ b/library/src/test/java/com/patloew/colocation/CoLocationTest.kt
@@ -113,14 +113,11 @@ class CoLocationTest {
         LocationRequest.PRIORITY_NO_POWER
     ])
     fun `cancelling getCurrentLocation cancels task`(priority: Int) {
-        lateinit var token: CancellationToken
+        val tokenSlot = slot<CancellationToken>()
 
         every {
-            locationProvider.getCurrentLocation(priority, any())
-        } answers {
-            token = arg(1)
-            mockk(relaxed = true)
-        }
+            locationProvider.getCurrentLocation(priority, capture(tokenSlot))
+        } returns mockk(relaxed = true)
 
         val deferred = testCoroutineScope.async(start = CoroutineStart.UNDISPATCHED) {
             coLocation.getCurrentLocation(priority)
@@ -129,7 +126,7 @@ class CoLocationTest {
         deferred.cancel()
 
         assertTrue(deferred.isCancelled)
-        assertTrue(token.isCancellationRequested)
+        assertTrue(tokenSlot.captured.isCancellationRequested)
     }
 
     @Test

--- a/library/src/test/java/com/patloew/colocation/CoLocationTest.kt
+++ b/library/src/test/java/com/patloew/colocation/CoLocationTest.kt
@@ -4,10 +4,7 @@ import android.content.Context
 import android.location.Location
 import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.location.*
-import com.google.android.gms.tasks.OnCanceledListener
-import com.google.android.gms.tasks.OnFailureListener
-import com.google.android.gms.tasks.OnSuccessListener
-import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.*
 import io.mockk.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
@@ -87,6 +84,52 @@ class CoLocationTest {
             expectedCancelException = TaskCancelledException(""),
             coLocationCall = { coLocation.isLocationAvailable() }
         )
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [
+        LocationRequest.PRIORITY_HIGH_ACCURACY,
+        LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
+        LocationRequest.PRIORITY_LOW_POWER,
+        LocationRequest.PRIORITY_NO_POWER
+    ])
+    fun getCurrentLocation(priority: Int) {
+        val location = mockk<Location>()
+        testTaskWithCancelReturns(
+            createTask = { locationProvider.getCurrentLocation(priority, any()) },
+            taskResult = location,
+            expectedResult = location,
+            expectedErrorException = TestException(),
+            cancelResult = null,
+            coLocationCall = { coLocation.getCurrentLocation(priority) }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [
+        LocationRequest.PRIORITY_HIGH_ACCURACY,
+        LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
+        LocationRequest.PRIORITY_LOW_POWER,
+        LocationRequest.PRIORITY_NO_POWER
+    ])
+    fun `cancelling getCurrentLocation cancels task`(priority: Int) {
+        lateinit var token: CancellationToken
+
+        every {
+            locationProvider.getCurrentLocation(priority, any())
+        } answers {
+            token = arg(1)
+            mockk(relaxed = true)
+        }
+
+        val deferred = testCoroutineScope.async(start = CoroutineStart.UNDISPATCHED) {
+            coLocation.getCurrentLocation(priority)
+        }
+
+        deferred.cancel()
+
+        assertTrue(deferred.isCancelled)
+        assertTrue(token.isCancellationRequested)
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for [`FusedLocationProviderClient.getCurrentLocation`](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient#getCurrentLocation(int,%20com.google.android.gms.tasks.CancellationToken)) which was added in version `17.1.0`: https://developers.google.com/android/guides/releases#september_23_2020

One question I had looking at the current implementation, is why not make use of the [Play Services integration](https://github.com/Kotlin/kotlinx.coroutines/tree/master/integration/kotlinx-coroutines-play-services) module from coroutines?

For consistency, I stuck with the current approach with `suspendCancellableCoroutine` in this PR.